### PR TITLE
User withdrawal#64

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -26,7 +26,7 @@ class AssignsController < ApplicationController
   end
 
   def assign_destroy(assign, assigned_user)
-    if assign.team.owner == current_user || assigned_user != current_user
+    if assign.team.owner != current_user && assigned_user != current_user
       'チームのオーナーであるか、そうでなければ自分自身以外は削除できません。'
     elsif assigned_user == assign.team.owner
       'リーダーは削除できません。'

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -26,7 +26,9 @@ class AssignsController < ApplicationController
   end
 
   def assign_destroy(assign, assigned_user)
-    if assigned_user == assign.team.owner
+    if assign.team.owner == current_user || assigned_user != current_user
+      'チームのオーナーであるか、そうでなければ自分自身以外は削除できません。'
+    elsif assigned_user == assign.team.owner
       'リーダーは削除できません。'
     elsif Assign.where(user_id: assigned_user.id).count == 1
       'このユーザーはこのチームにしか所属していないため、削除できません。'

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,8 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_team, only: %i[show edit update destroy]
+  before_action :authenticate_team_owner, only: %i[update]
+
 
   def index
     @teams = Team.all
@@ -56,4 +58,13 @@ class TeamsController < ApplicationController
   def team_params
     params.fetch(:team, {}).permit %i[name icon icon_cache owner_id keep_team_id]
   end
+
+  def authenticate_team_owner
+    # @team = Team.find(params[:team])
+    if @team.owner != current_user
+      # redirect_to teams_url, notice: 'オーナー以外は編集できません、、'
+      # flash.now[:error] = 'オーナー以外は編集できません、、'
+      redirect_to @team,notice: 'オーナー以外は編集できません、、'
+    end
+  end    
 end


### PR DESCRIPTION
- Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできない機能の実装
- TeamのeditはTeamのリーダー（オーナー）のみができるようにする機能の実装